### PR TITLE
fix($compile): Get Step-3 to a working stage

### DIFF
--- a/Step-3/app/build.gradle
+++ b/Step-3/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 27
-    buildToolsVersion '27.0.2'
+    buildToolsVersion '27.0.3'
     defaultConfig {
         applicationId "xyz.vivekc.webrtccodelab"
         minSdkVersion 21
@@ -27,7 +27,7 @@ android {
 dependencies {
     //    implementation project(':libwebrtc')
     //        compile fileTree(include: ['*.jar'], dir: 'libs/libwebrtc61')
-    implementation 'org.webrtc:google-webrtc:1.0.+'
+    implementation 'org.webrtc:google-webrtc:1.0.22672'
     //CR 21770
     androidTestImplementation('com.android.support.test.espresso:espresso-core:2.2.2', {
         exclude group: 'com.android.support', module: 'support-annotations'

--- a/Step-3/app/src/main/java/xyz/vivekc/webrtccodelab/TurnServer.java
+++ b/Step-3/app/src/main/java/xyz/vivekc/webrtccodelab/TurnServer.java
@@ -2,6 +2,8 @@ package xyz.vivekc.webrtccodelab;
 
 import retrofit2.Call;
 import retrofit2.http.GET;
+import retrofit2.http.Header;
+import retrofit2.http.PUT;
 
 /**
  * Webrtc_Step3
@@ -10,6 +12,6 @@ import retrofit2.http.GET;
 
 
 public interface TurnServer {
-    @GET("ice?ident=vivekchanddru&secret=ad6ce53a-e6b5-11e6-9685-937ad99985b9&domain=www.vivekc.xyz&application=default&room=testing&secure=1")
-    Call<TurnServerPojo> getIceCandidates();
+    @PUT("/_turn/<xyrsys_channel>")
+    Call<TurnServerPojo> getIceCandidates(@Header("Authorization") String authkey);
 }

--- a/Step-3/app/src/main/java/xyz/vivekc/webrtccodelab/TurnServerPojo.java
+++ b/Step-3/app/src/main/java/xyz/vivekc/webrtccodelab/TurnServerPojo.java
@@ -17,7 +17,7 @@ public class TurnServerPojo {
     @SerializedName("e")
     @Expose
     public Object e;
-    @SerializedName("d")
+    @SerializedName("v")
     @Expose
     public IceServerList iceServerList;
 

--- a/Step-3/app/src/main/java/xyz/vivekc/webrtccodelab/Utils.java
+++ b/Step-3/app/src/main/java/xyz/vivekc/webrtccodelab/Utils.java
@@ -11,7 +11,7 @@ import retrofit2.converter.gson.GsonConverterFactory;
 public class Utils {
 
     static Utils instance;
-    public static final String API_ENDPOINT = "https://service.xirsys.com";
+    public static final String API_ENDPOINT = "https://global.xirsys.net";
 
     public static Utils getInstance() {
         if (instance == null) {


### PR DESCRIPTION
Update to meet changes in WebRTC library and Xirsys API

VideoRendered was deprecated from the WebRTC library and now instead the VideoView is added to the
VideoTrack by calling the method addSink.  Moreover the Xirsys API has changes and now requires
Basic Authentication, which is performed using Retrofit.